### PR TITLE
Add IBUS protocol support

### DIFF
--- a/src/IBUS.cpp
+++ b/src/IBUS.cpp
@@ -24,7 +24,7 @@ void IBUS::begin(Stream& stream)
     this->lchksum = 0;
 }
 
-void IBUS::loop(void)
+void ICACHE_RAM_ATTR IBUS::loop(void)
 {
     extern SoftwareSerial usbSerial;
     while (stream->available() > 0)

--- a/src/IBUS.cpp
+++ b/src/IBUS.cpp
@@ -1,0 +1,101 @@
+/**
+ * Simple interface to the Fly Sky IBus RC system.
+ * https://gitlab.com/timwilkinson/FlySkyIBus
+ */
+
+#include <Arduino.h>
+#include "IBUS.h"
+#include <SoftwareSerial.h>
+
+IBUS::IBUS(HardwareSerial& serial)
+{
+    serial.begin(115200);
+    begin((Stream&)serial);
+}
+
+void IBUS::begin(Stream& stream)
+{
+    this->stream = &stream;
+    this->state = GET_LENGTH;
+    this->last = 0;
+    this->ptr = 0;
+    this->len = 0;
+    this->chksum = 0;
+    this->lchksum = 0;
+}
+
+void IBUS::loop(void)
+{
+    extern SoftwareSerial usbSerial;
+    while (stream->available() > 0)
+    {
+        // uint32_t now = millis();
+        // if (now - last >= PROTOCOL_TIMEGAP)
+        // {
+        //     state = GET_LENGTH;
+        // }
+        // last = now;
+
+        uint8_t v = stream->read();
+        switch (state)
+        {
+        case GET_LENGTH:
+            if (v <= PROTOCOL_LENGTH)
+            {
+                ptr = 0;
+                len = v - PROTOCOL_OVERHEAD;
+                chksum = 0xFFFF - v;
+                state = GET_DATA;
+            }
+            else
+            {
+                state = GET_LENGTH;
+            }
+            break;
+
+        case GET_DATA:
+            buffer[ptr++] = v;
+            chksum -= v;
+            if (ptr == len)
+            {
+                state = GET_CHKSUML;
+            }
+            break;
+
+        case GET_CHKSUML:
+            lchksum = v;
+            state = GET_CHKSUMH;
+            break;
+
+        case GET_CHKSUMH:
+            // Validate checksum
+            if (chksum == (v << 8) + lchksum)
+            {
+                // Execute command - we only know command 0x40
+                switch (buffer[0])
+                {
+                    case PROTOCOL_COMMAND40:
+                    // Valid - extract channel data
+                    for (uint8_t i = 1; i < PROTOCOL_CHANNELS * 2 + 1; i += 2)
+                    {
+                        ChannelDataIn[i / 2] = buffer[i] | (buffer[i + 1] << 8);
+                    }
+                    //usbSerial.print(ChannelDataIn[2], DEC);
+                    if (RCdataCallback)
+                        RCdataCallback();
+                    break;
+
+                    default:
+                    break;
+                }
+            }
+            state = GET_LENGTH;
+            break;
+
+        case DISCARD:
+        default:
+            break;
+        }
+    }
+}
+

--- a/src/IBUS.h
+++ b/src/IBUS.h
@@ -1,0 +1,46 @@
+/**
+ * Simple interface to the Fly Sky IBus RC system.
+ * https://gitlab.com/timwilkinson/FlySkyIBus
+ */
+
+#include <inttypes.h>
+
+class HardwareSerial;
+class Stream;
+
+class IBUS
+{
+public:
+    IBUS(HardwareSerial& serial);
+    void loop(void);
+    uint16_t ChannelDataIn[16];
+
+    void (*RCdataCallback)(); //function pointer for new RC data callback
+
+private:
+    void begin(Stream& stream);
+
+    enum State
+    {
+        GET_LENGTH,
+        GET_DATA,
+        GET_CHKSUML,
+        GET_CHKSUMH,
+        DISCARD,
+    };
+
+    static const uint8_t PROTOCOL_LENGTH = 0x20;
+    static const uint8_t PROTOCOL_OVERHEAD = 3; // <len><cmd><data....><chkl><chkh>
+    static const uint8_t PROTOCOL_TIMEGAP = 3; // Packets are received very ~7ms so use ~half that for the gap
+    static const uint8_t PROTOCOL_CHANNELS = 10;
+    static const uint8_t PROTOCOL_COMMAND40 = 0x40; // Command is always 0x40
+
+    uint8_t state;
+    Stream* stream;
+    uint32_t last;
+    uint8_t buffer[PROTOCOL_LENGTH];
+    uint8_t ptr;
+    uint8_t len;
+    uint16_t chksum;
+    uint8_t lchksum;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@ auto &testSerial = Serial;
 //#define USE_GHST
 #define USE_CRSF
 //#define USE_SBUS
+//#define USE_IBUS
 ////#define USE_SRXL2
 
 bool testRunning = false;
@@ -31,6 +32,11 @@ CRSF crsf(Serial);
 SBUS sbus(Serial);
 bool failSafe;
 bool lostFrame;
+#endif
+
+#ifdef USE_IBUS
+#include "IBUS.h"
+IBUS ibus(Serial);
 #endif
 
 #ifdef USE_SRXL2
@@ -153,6 +159,8 @@ void inline CRSF_GHST_RC_CALLBACK()
   RCcallback(crsf.ChannelDataIn);
 #elif defined(USE_GHST)
   RCcallback(ghst.ChannelDataIn);
+#elif defined(USE_IBUS)
+  RCcallback(ibus.ChannelDataIn);
 #endif
 }
 
@@ -188,6 +196,8 @@ void setup()
   Serial.begin(GHST_RX_BAUDRATE, SERIAL_8N1, SERIAL_FULL, 1, false);
 #elif defined(USE_SBUS)
   sbus.begin();
+#elif defined(USE_IBUS)
+  ibus.RCdataCallback = &CRSF_GHST_RC_CALLBACK;
 #endif
 
   Serial.swap();
@@ -278,6 +288,8 @@ void loop()
   loop_srxl2();
 #elif defined(USE_SBUS)
   loop_sbus();
+#elif defined(USE_IBUS)
+  ibus.loop();
 #endif
 
   if (digitalRead(0) == 0)


### PR DESCRIPTION
Hey if UAVTech is going to test SBUS, let's test IBUS too.

This adds the IBUS protocol to the tester using the USE_IBUS define. Just plug an IBUS RX into the serial same as everyone else. The code is a straight copypasta from [Tim Wilkinson's FlySkyIBus](https://gitlab.com/timwilkinson/FlySkyIBus) which I have adapted to fit the RClatentecyTester's style. The project has no license but I think that's why this project exists, right?

I'd hope Mark will get some better numbers for IBUS because the interval I have seen in some of his older videos seems out of line with everything I've ever programmed for the IBUS protocol.

EDIT: FIRST PULL REQUEST **I win, wake up and merge this, Sandro!**